### PR TITLE
Frozen sets correction

### DIFF
--- a/FPTree-algorithm.py
+++ b/FPTree-algorithm.py
@@ -17,7 +17,10 @@ def Load_data(filename):
 def create_initialset(dataset):
     retDict = {}
     for trans in dataset:
-        retDict[frozenset(trans)] = 1
+	if frozenset(trans) in retDict.keys():
+	    retDict[frozenset(trans)] += 1
+	else:
+            retDict[frozenset(trans)] = 1
     return retDict
 
 #class of FP TREE node


### PR DESCRIPTION
Changes to function - create_initialset (To convert the initial transaction into frozenset)

**Modifications suggested:**
When the transactions are converted to frozensets, the support count of the individual item has to be retained to avoid the loss of support count.
for example - in the file small-test-input.txt provided in the same repo, the transactions in line number - 3 and line number - 6 are {2,3}. Here when the transactions are to be converted to frozenset, the corresponding count in the frozenset should be as follows:
{ frozenset{2,3}, 2 }, here number 2 for the value in this dict indicates its occurrence to be twice in the transaction list.

Currently, the value would be { frozenset{2,3}, 1 } which loses the support count information of these items.
The code change provided will retain the support count of individual items, thereby not losing repetitive transaction information from the database. This helps in generating a correct FP Tree and in turn generation of frequent itemsets.